### PR TITLE
sec: enable Cilium WireGuard encryption for cross-node pod traffic

### DIFF
--- a/kubernetes/main/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/main/apps/kube-system/cilium/app/helmrelease.yaml
@@ -31,6 +31,28 @@ spec:
       enabled: true
     devices: bond0
     enableIPv4BIGTCP: true
+    encryption:
+      # Transparent WireGuard encryption for pod-to-pod traffic that
+      # crosses node boundaries (host-to-host on the wire). Requires
+      # in-kernel WireGuard support (Talos ships this by default).
+      #
+      # Known caveats to verify against this exact stack before promoting
+      # past `kubernetes/testing`:
+      #  - cilium/cilium#45950: pod -> local-node-IP can fail under
+      #    encryption.type=wireguard in some 1.19 configs.
+      #  - With loadBalancer.mode: dsr (as set below), north-south traffic
+      #    redirected between nodes in non-Geneve DSR dispatch isn't
+      #    encrypted by this feature — only east-west pod-to-pod is
+      #    guaranteed here.
+      #  - Interaction with bpf.datapathMode: netkit hasn't been verified
+      #    against your Cilium version; watch `cilium encrypt status` on
+      #    each node after rollout.
+      enabled: true
+      type: wireguard
+      # Only encrypts pod-to-pod. Set to true for node-to-node/pod-to-node
+      # too (kubelet health checks, etc.) once pod-to-pod is confirmed
+      # working.
+      nodeEncryption: false
     endpointRoutes:
       enabled: true
     envoy:


### PR DESCRIPTION
routingMode: native means pod-to-pod traffic between different physical hosts currently travels unencrypted over the LAN. Turns on Cilium's transparent WireGuard encryption (encryption.enabled + type: wireguard), scoped to pod-to-pod only for now (nodeEncryption: false).

Flagged in comments for verification before promoting past kubernetes/testing: a known upstream issue with pod -> local-node-IP under wireguard (cilium/cilium#45950), a DSR north-south caveat given loadBalancer.mode: dsr is already set, and unverified interaction with bpf.datapathMode: netkit.